### PR TITLE
replace pax-cdi-api with blueprint-maven-plugin-annotation

### DIFF
--- a/bundle-parent/pom.xml
+++ b/bundle-parent/pom.xml
@@ -31,13 +31,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-       <!-- TODO remove this again when pax-cdi-api has been replaced with Blueprint annotations. -->
-       <groupId>org.ops4j.pax.cdi</groupId>
-       <artifactId>pax-cdi-api</artifactId>
-       <optional>true</optional>
-       <version>1.0.0.RC2</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <exclusions>

--- a/ds/pom.xml
+++ b/ds/pom.xml
@@ -45,10 +45,10 @@
       <artifactId>sal-core-compat</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.ops4j.pax.cdi</groupId>
-      <artifactId>pax-cdi-api</artifactId>
-      <optional>true</optional>
-    </dependency>
+     <groupId>org.apache.aries.blueprint</groupId>
+     <artifactId>blueprint-maven-plugin-annotation</artifactId>
+     <optional>true</optional>
+   </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -73,14 +73,6 @@
       <plugin>
         <groupId>org.apache.aries.blueprint</groupId>
         <artifactId>blueprint-maven-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <!-- TODO remove this weird hack after version bump... -->
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-dom-api</artifactId>
-            <version>3.0.6</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/ds/src/main/java/org/opendaylight/etcd/ds/impl/EtcdDOMDataBroker.java
+++ b/ds/src/main/java/org/opendaylight/etcd/ds/impl/EtcdDOMDataBroker.java
@@ -15,10 +15,10 @@ import java.io.File;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.aries.blueprint.annotation.service.Reference;
 import org.opendaylight.mdsal.dom.api.DOMDataBroker;
 import org.opendaylight.mdsal.dom.api.DOMSchemaService;
 import org.opendaylight.mdsal.dom.spi.ForwardingDOMDataBroker;
-import org.ops4j.pax.cdi.api.OsgiService;
 
 /**
  * {@link DOMDataBroker} registered in the OSGi service registry.
@@ -26,14 +26,14 @@ import org.ops4j.pax.cdi.api.OsgiService;
  * @author Michael Vorburger.ch
  */
 @Singleton
-// do NOT @OsgiServiceProvider(classes = DOMDataBroker.class), because we need odl:type="default" so BP XML
+// do NOT @Service(classes = DOMDataBroker.class), because we need odl:type="default" so BP XML
 public class EtcdDOMDataBroker extends ForwardingDOMDataBroker {
 
     private final EtcdDOMDataBrokerProvider wiring;
 
     @Inject
-    public EtcdDOMDataBroker(@OsgiService DOMSchemaService schemaService) throws Exception {
-        // TODO Remove this constructor with hard-coded etcd server endpoint by using @OsgiService Client (below)
+    public EtcdDOMDataBroker(@Reference DOMSchemaService schemaService) throws Exception {
+        // TODO Remove this constructor with hard-coded etcd server endpoint by using @Reference Client (below)
         // For the moment this does not work, most probably because of the org/opendaylight/blueprint/ds-blueprint.xml
         // which we need so that we can look up other OSGi services which mdsal and controller registered; this should
         // get solved with odlparent 4.0.0 which does away with org/opendaylight/blueprint and the 2 (std VS odl) BPs.
@@ -48,7 +48,7 @@ public class EtcdDOMDataBroker extends ForwardingDOMDataBroker {
     }
 
     // the Client is set up in the OSGi Service registry by io.etcd:jetcd-osgi, based on etc/io.etcd.jetcd.cfg
-    public EtcdDOMDataBroker(@OsgiService DOMSchemaService schemaService, @OsgiService Client etcdClient)
+    public EtcdDOMDataBroker(@Reference DOMSchemaService schemaService, @Reference Client etcdClient)
             throws Exception {
         wiring = new EtcdDOMDataBrokerProvider(etcdClient, "", schemaService);
         wiring.init();

--- a/eos/pom.xml
+++ b/eos/pom.xml
@@ -27,10 +27,10 @@
       <artifactId>mdsal-eos-dom-simple</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.ops4j.pax.cdi</groupId>
-      <artifactId>pax-cdi-api</artifactId>
-      <optional>true</optional>
-    </dependency>
+     <groupId>org.apache.aries.blueprint</groupId>
+     <artifactId>blueprint-maven-plugin-annotation</artifactId>
+     <optional>true</optional>
+   </dependency>
   </dependencies>
 
   <build>

--- a/eos/src/main/java/org/opendaylight/etcd/eos/impl/EtcdDOMEntityOwnershipService.java
+++ b/eos/src/main/java/org/opendaylight/etcd/eos/impl/EtcdDOMEntityOwnershipService.java
@@ -9,9 +9,9 @@ package org.opendaylight.etcd.eos.impl;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.aries.blueprint.annotation.service.Service;
 import org.opendaylight.mdsal.eos.dom.api.DOMEntityOwnershipService;
 import org.opendaylight.mdsal.eos.dom.simple.SimpleDOMEntityOwnershipService;
-import org.ops4j.pax.cdi.api.OsgiServiceProvider;
 
 /**
  * DOMEntityOwnershipService implementation, based on etcd.
@@ -19,7 +19,7 @@ import org.ops4j.pax.cdi.api.OsgiServiceProvider;
  * @author Michael Vorburger.ch
  */
 @Singleton
-@OsgiServiceProvider(classes = DOMEntityOwnershipService.class)
+@Service(classes = DOMEntityOwnershipService.class)
 public class EtcdDOMEntityOwnershipService extends DelegatingDOMEntityOwnershipService {
 
     // TODO replace this fake (simple) EOS by a real one backed by etcd...


### PR DESCRIPTION
This applies another (the last, hopefully) Neon Platform Upgrade step.

https://wiki.opendaylight.org/view/Neon_platform_upgrade#Blueprint_declarations